### PR TITLE
Fix usage of unbound global requestAnimationFrame

### DIFF
--- a/src/injectable/CancelAnimationFrame.js
+++ b/src/injectable/CancelAnimationFrame.js
@@ -1,5 +1,5 @@
 var CancelAnimationFrame = {
-  current: global.cancelAnimationFrame,
+  current: id => global.cancelAnimationFrame(id),
   inject(injected) {
     CancelAnimationFrame.current = injected;
   },

--- a/src/injectable/RequestAnimationFrame.js
+++ b/src/injectable/RequestAnimationFrame.js
@@ -1,5 +1,5 @@
 var RequestAnimationFrame = {
-  current: global.requestAnimationFrame,
+  current: cb => global.requestAnimationFrame(cb),
   inject(injected) {
     RequestAnimationFrame.current = injected;
   },


### PR DESCRIPTION
Fixes small issue where `requestAnimationFrame` needs to have `window` as it's context.

TODO: we should maybe provide browser-prefixed fallbacks in the default as well?
