### PR TITLE
ApplyAnimatedValues implementation for browser

### DIFF
--- a/src/Animated.js
+++ b/src/Animated.js
@@ -1146,7 +1146,7 @@ function createAnimatedComponent(Component: any): any {
 
     setNativeProps(props) {
       var didUpdate = ApplyAnimatedValues.current(this.refs[refName], props);
-      if (shouldUpdate === false) {
+      if (didUpdate === false) {
         this.forceUpdate();
       }
     }
@@ -1166,7 +1166,7 @@ function createAnimatedComponent(Component: any): any {
       // forceUpdate.
       var callback = () => {
         var didUpdate = ApplyAnimatedValues.current(this.refs[refName], this._propsAnimated.__getAnimatedValue());
-        if (shouldUpdate === false) {
+        if (didUpdate === false) {
           this.forceUpdate();
         }
       };
@@ -1718,6 +1718,7 @@ module.exports = {
   createAnimatedComponent,
 
   inject: {
+    ApplyAnimatedValues: ApplyAnimatedValues.inject,
     InteractionManager: InteractionManager.inject,
     FlattenStyle: FlattenStyle.inject,
     RequestAnimationFrame: RequestAnimationFrame.inject,

--- a/src/targets/react-dom.js
+++ b/src/targets/react-dom.js
@@ -13,14 +13,28 @@
 var CSSPropertyOperations = require('react/lib/CSSPropertyOperations');
 var Animated = require('../Animated');
 
+// { scale: 2 } => 'scale(2)'
+function mapTransform(t) {
+  var k = Object.keys(t)[0];
+  return `${k}(${t[k]})`;
+}
+
+// NOTE(lmr):
+// Since this is a hot code path, right now this is mutative...
+// As far as I can tell, this shouldn't cause any unexpected behavior.
+function mapStyle(style) {
+  if (style && style.transform) {
+    // TODO(lmr): this doesn't attempt to use vendor prefixed styles
+    style.transform = style.transform.map(mapTransform).join(' ');
+  }
+  return style;
+}
+
 function ApplyAnimatedValues(instance, props) {
   if (instance.setNativeProps) {
     instance.setNativeProps(props);
-  } else if (instance.getDOMNode) {
-    var node = instance.getDOMNode();
-    if (node.setAttribute) {
-      var strStyle = CSSPropertyOperations.setValueForStyles(node, props.style, instance);
-    }
+  } else if (instance.nodeType && instance.setAttribute !== undefined) {
+    CSSPropertyOperations.setValueForStyles(instance, mapStyle(props.style), instance);
   } else {
     return false;
   }


### PR DESCRIPTION
to: @vjeux @browniefed 

I tweaked the implementation for the injected `ApplyAnimatedValues` in the browser environment.

It now accepts style with transforms in the form of an array, similar to React Native. 

Notes:
1. This doesn't attempt to use browser-prefixed CSS styles, but it could (improving compatibility).
2. Since I'm no longer using `getDOMNode()`, this is not compatible with React 0.13, but we could easily add that in.
3. This also includes a variable naming goof that I made with `shouldUpdate` => `didUpdate`.
