### PR TITLE
Fix mapTransform, added px to value for translateX and translateY.

### DIFF
--- a/src/targets/react-dom.js
+++ b/src/targets/react-dom.js
@@ -16,7 +16,11 @@ var Animated = require('../');
 // { scale: 2 } => 'scale(2)'
 function mapTransform(t) {
   var k = Object.keys(t)[0];
-  return `${k}(${t[k]})`;
+  if (k === 'translateX' || k === 'translateY') {
+    return k+'('+t[k]+'px)';
+  } else {
+    return k+'('+t[k]+')';
+  }
 }
 
 // NOTE(lmr):


### PR DESCRIPTION
Currently when Animated.div is rendered using style like:
`style={{transform: [{translateX: this.state.x}, {translateY: this.state.y}]}}`
no inline style is added in the DOM because the value is unitless. This works ok for scale() but not for translateX and translateY where the value needs to be in px or %.
