### PR TITLE
Round interpolation for RGB components

### DIFF
--- a/src/Interpolation.js
+++ b/src/Interpolation.js
@@ -222,13 +222,18 @@ function createInterpolationFromStringOutputRange(
     });
   });
 
+  // rgba requires that the r,g,b are integers.... so we want to round them, but we *dont* want to
+  // round the opacity (4th column).
+  const shouldRound = (/^rgb/).test(outputRange[0]);
+
   return (input) => {
     var i = 0;
     // 'rgba(0, 100, 200, 0)'
     // ->
     // 'rgba(${interpolations[0](input)}, ${interpolations[1](input)}, ...'
     return outputRange[0].replace(stringShapeRegex, () => {
-      return String(interpolations[i++](input));
+      const val = interpolations[i++](input);
+      return String(shouldRound && i < 4 ? Math.round(val) : val);
     });
   };
 }


### PR DESCRIPTION
The CSS spec doesn't allow for decimal values inside of `rgb`, however the RN implementation does, so there was a disconnect here.

This tests to see if the output range is an rgb color, and if so, rounds the first 3 interpolated components (but not the 4th, since that would be opacity and allows for a decimal).

cc @vjeux 
