### PR TITLE
Disable the transform codepath when the value is an Animable

### DIFF
--- a/src/AnimatedStyle.js
+++ b/src/AnimatedStyle.js
@@ -21,7 +21,7 @@ class AnimatedStyle extends AnimatedWithChildren {
   constructor(style: any) {
     super();
     style = FlattenStyle.current(style) || {};
-    if (style.transform) {
+    if (style.transform && !(style.transform instanceof Animated)) {
       style = {
         ...style,
         transform: new AnimatedTransform(style.transform),

--- a/src/targets/react-dom.js
+++ b/src/targets/react-dom.js
@@ -23,7 +23,7 @@ function mapTransform(t) {
 // Since this is a hot code path, right now this is mutative...
 // As far as I can tell, this shouldn't cause any unexpected behavior.
 function mapStyle(style) {
-  if (style && style.transform) {
+  if (style && style.transform && typeof style.transform !== 'string') {
     // TODO(lmr): this doesn't attempt to use vendor prefixed styles
     style.transform = style.transform.map(mapTransform).join(' ');
   }


### PR DESCRIPTION
@vjeux I've just checked my PR on my app, and this commit is actually required to make the PR work correctly with transforms (otherwise, the library expects to get an array). Sorry for not checking before :(
