### PR TITLE
Fix CSSPropertyOperations import for react-dom 15.4.0 and higher

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "babel-preset-react": "^6.5.0",
     "babel-preset-react-native": "^1.4.0",
     "browserify": "^13.0.0",
-    "react": "^15.1.0",
-    "react-dom": "^15.1.0"
+    "react": "^15.4.0",
+    "react-dom": "^15.4.0"
   }
 }

--- a/src/targets/react-dom.js
+++ b/src/targets/react-dom.js
@@ -10,7 +10,7 @@
  */
 'use strict';
 
-var CSSPropertyOperations = require('react/lib/CSSPropertyOperations');
+var CSSPropertyOperations = require('react-dom/lib/CSSPropertyOperations');
 var Animated = require('../');
 
 // { scale: 2 } => 'scale(2)'


### PR DESCRIPTION
This PR is relevant to #51, Also bumped the dependency of react and react-dom to version 15.4.0, because it would break with versions of react prior to 15.4.0