### PR TITLE
Use function ref in createAnimatedComponent()

### DIFF
--- a/src/createAnimatedComponent.js
+++ b/src/createAnimatedComponent.js
@@ -15,8 +15,6 @@ var AnimatedProps = require('./AnimatedProps');
 var ApplyAnimatedValues = require('./injectable/ApplyAnimatedValues');
 
 function createAnimatedComponent(Component: any): any {
-  var componentRef;
-
   class AnimatedComponent extends React.Component {
     _propsAnimated: AnimatedProps;
 
@@ -81,6 +79,10 @@ function createAnimatedComponent(Component: any): any {
           ref={node => { this.componentRef = node; }}
         />
       );
+    }
+    
+    getNode() {
+      return this.componentRef;
     }
   }
   AnimatedComponent.propTypes = {

--- a/src/createAnimatedComponent.js
+++ b/src/createAnimatedComponent.js
@@ -15,7 +15,7 @@ var AnimatedProps = require('./AnimatedProps');
 var ApplyAnimatedValues = require('./injectable/ApplyAnimatedValues');
 
 function createAnimatedComponent(Component: any): any {
-  var refName = 'node';
+  var componentRef;
 
   class AnimatedComponent extends React.Component {
     _propsAnimated: AnimatedProps;
@@ -25,7 +25,7 @@ function createAnimatedComponent(Component: any): any {
     }
 
     setNativeProps(props) {
-      var didUpdate = ApplyAnimatedValues.current(this.refs[refName], props, this);
+      var didUpdate = ApplyAnimatedValues.current(this.componentRef, props, this);
       if (didUpdate === false) {
         this.forceUpdate();
       }
@@ -45,7 +45,7 @@ function createAnimatedComponent(Component: any): any {
       // need to re-render it. In this case, we have a fallback that uses
       // forceUpdate.
       var callback = () => {
-        var didUpdate = ApplyAnimatedValues.current(this.refs[refName], this._propsAnimated.__getAnimatedValue(), this);
+        var didUpdate = ApplyAnimatedValues.current(this.componentRef, this._propsAnimated.__getAnimatedValue(), this);
         if (didUpdate === false) {
           this.forceUpdate();
         }
@@ -78,7 +78,7 @@ function createAnimatedComponent(Component: any): any {
         <Component
           {...other}
           style={ApplyAnimatedValues.transformStyles(style)}
-          ref={refName}
+          ref={node => { this.componentRef = node; }}
         />
       );
     }


### PR DESCRIPTION
This seems to increase support for functional components and custom primitive components (like those in other renderers). Also, string refs will be deprecated soon.