### PR TITLE
fix scientific notation bug in interpolation

### DIFF
--- a/src/Interpolation.js
+++ b/src/Interpolation.js
@@ -172,7 +172,7 @@ function colorToRgba(input: string): string {
   return `rgba(${r}, ${g}, ${b}, ${a})`;
 }
 
-var stringShapeRegex = /[0-9\.-]+/g;
+var stringShapeRegex = /([0-9]\d*)(?:\.\d*)?(?:[eE][+\-]?\d+)?/g;
 
 /**
  * Supports string shapes by extracting numbers so new values can be computed,


### PR DESCRIPTION
There is currently a bug in animated that is causing deeply nested side-effects. 

[This line](https://github.com/animatedjs/animated/blob/master/src/Interpolation.js#L234) will in some situations return a scientific number, which stringShapeRegex can't track, it thereby creates a wrong outputShape (for instance: `[-7]`) which causes trouble later on. Basically it starts adding `Nan` to the interpolated result, so output can look like this: `1-e7NaNNaNNaNNaNNaNNaNdeg` - and it's adding up, blowing up memory. 

I am not sure if the new regexp is covering all cases, but it fixed the problems i've had (an AnimatedValue visually stopped working).